### PR TITLE
Змінні самі по собі не викликають помилки + typos

### DIFF
--- a/manuscript/01-Block-Bindings.md
+++ b/manuscript/01-Block-Bindings.md
@@ -149,7 +149,7 @@ if (condition) {
 var message = "Hello!";
 let age = 25;
 
-// Кожна із цих змінник викличе помилку
+// Оголошення кожної із цих змінних викличе помилку
 const message = "Goodbye!";
 const age = 30;
 ```


### PR DESCRIPTION
Помилки можуть викликати тільки операції, які з ними відбуваються